### PR TITLE
add as command attribute to classes

### DIFF
--- a/src/Commands/InstallDriversCommand.php
+++ b/src/Commands/InstallDriversCommand.php
@@ -3,18 +3,18 @@
 namespace Mindtwo\ValetDrivers\Commands;
 
 use DirectoryIterator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'install',
+    description: 'Effortlessly install custom valet drivers for enhanced development on mindtwo projects.'
+)]
 class InstallDriversCommand extends BaseCommand
 {
-    /**
-     * @var string
-     */
-    protected static $defaultName = 'install';
-
     /**
      * @var string
      */

--- a/src/Commands/UninstallDriversCommand.php
+++ b/src/Commands/UninstallDriversCommand.php
@@ -3,23 +3,18 @@
 namespace Mindtwo\ValetDrivers\Commands;
 
 use DirectoryIterator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'uninstall',
+    description: 'Effortlessly install custom valet drivers for enhanced development on mindtwo projects.'
+)]
 class UninstallDriversCommand extends BaseCommand
 {
-    /**
-     * @var string
-     */
-    protected static $defaultName = 'uninstall';
-
-    /**
-     * @var string
-     */
-    protected static $defaultDescription = 'Removes mindtwo custom valet drivers from both Valet and Herd unless specified otherwise.';
-
     private OutputInterface $output;
 
     protected function configure(): void


### PR DESCRIPTION
With dep updates it is required to use the AsCommand attribute for the symfony framework.